### PR TITLE
Preparation for server rendering

### DIFF
--- a/components/MuiTheme.ts
+++ b/components/MuiTheme.ts
@@ -8,8 +8,8 @@ export const MuiTheme = createMuiTheme({
   palette: {
     primary: {
       light: "#ffffff",
-      main: "#73ce3b",
-      dark: "#78b253",
+      main: "#62834e",
+      dark: "#ffffff",
     },
 
     secondary: {

--- a/components/MuiTheme.ts
+++ b/components/MuiTheme.ts
@@ -7,9 +7,9 @@ import { createMuiTheme } from "@material-ui/core/styles"
 export const MuiTheme = createMuiTheme({
   palette: {
     primary: {
-      light: "#ffffff",
+      light: "#99c97c",
       main: "#62834e",
-      dark: "#ffffff",
+      dark: "#99c97c",
     },
 
     secondary: {

--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -20,7 +20,6 @@ const useStyles = makeStyles(theme => ({
   content: {
     flexGrow: 1,
     height: "100vh",
-    overflow: "auto",
   },
   titleLight: {
     display: "flex",
@@ -35,10 +34,11 @@ type Props = {
   children: React.ReactNode
   className?: string
   color?: any
+  title?: string
 }
 
 export const BasePage = function(props: Props) {
-  const { children, className, color } = props
+  const { children, className, color, title } = props
   const classes = useStyles(props)
   
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
@@ -70,7 +70,7 @@ export const BasePage = function(props: Props) {
                 href="/visible-children"
                 className={classes.titleLight}
               >
-                Your title
+                {title}
               </Link>
             </Typography>
             <div style={{ float: "right", width: "6%"}}>

--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -22,29 +22,23 @@ const useStyles = makeStyles(theme => ({
     height: "100vh",
     overflow: "auto",
   },
-  mongenTitleLight: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingTop: "2%",
-    color: "black",
-  },
   titleLight: {
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    paddingTop: "3%",
-    color: "black",
+    paddingTop: "7%",
+    color: "#edf2ea",
   },
 }))
 
 type Props = {
   children: React.ReactNode
   className?: string
+  color?: any
 }
 
 export const BasePage = function(props: Props) {
-  const { children, className } = props
+  const { children, className, color } = props
   const classes = useStyles(props)
   
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
@@ -64,7 +58,7 @@ export const BasePage = function(props: Props) {
     <div className={`${classes.root} ${className}`}>
         {/* top nav bar with mongen name */}
       <CssBaseline />
-      <AppBar position="absolute">
+      <AppBar position="absolute" style={{color: `${color}`}}>
         <Toolbar>
           <div  style={{ width: "100%"}}>
             <Typography
@@ -73,10 +67,10 @@ export const BasePage = function(props: Props) {
             >
               <Link
                 underline="none"
-                href="/"
+                href="/visible-children"
                 className={classes.titleLight}
               >
-                Mongen Initiative
+                Your title
               </Link>
             </Typography>
             <div style={{ float: "right", width: "6%"}}>
@@ -118,26 +112,8 @@ export const BasePageAboutMongen = function(props: Props) {
     <div className={`${classes.root} ${className}`}>
         {/* top nav bar with mongen name */}
       <CssBaseline />
-      <AppBar position="absolute">
-        <Toolbar>
-          <div  style={{ width: "100%"}}>
-            <Typography
-              variant="h5"
-              style={{ fontWeight: 400, fontSize: "1.8em", float: "left"}}
-            >
-              <Link
-                underline="none"
-                href="/"
-                className={classes.mongenTitleLight}
-              >
-                Mongen Initiative
-              </Link>
-            </Typography>
-          </div>
-        </Toolbar>
-      </AppBar>
       <main className={classes.content}>
-        <div className={classes.spaceAfterNavBar} />
+        <div style={{marginTop:"30px"}} />
           {/* all the main body */}
         <section>{children}</section>
       </main>

--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -53,6 +53,7 @@ export const BasePage = function(props: Props) {
   
   const router = useRouter()
 
+  const url = convertTitleToSeoUrl(title)
   
   return (
     <div className={`${classes.root} ${className}`}>
@@ -67,7 +68,7 @@ export const BasePage = function(props: Props) {
             >
               <Link
                 underline="none"
-                href="/visible-children"
+                href={`/${url}`}
                 className={classes.titleLight}
               >
                 {title}
@@ -119,4 +120,19 @@ export const BasePageAboutMongen = function(props: Props) {
       </main>
     </div>
   )
+}
+
+export function convertTitleToSeoUrl(title) {
+  if(typeof title === "string"){
+    return title
+        .normalize('NFD')               // Change diacritics
+        .replace(/[\u0300-\u036f]/g,'') // Remove illegal characters
+        .replace(/\s+/g,'-')            // Change whitespace to dashes
+        .toLowerCase()                  // Change to lowercase
+        .replace(/&/g,'-and-')          // Replace ampersand
+        .replace(/[^a-z0-9\-]/g,'')     // Remove anything that is not a letter, number or dash
+        .replace(/-+/g,'-')             // Remove duplicate dashes
+        .replace(/^-*/,'')              // Remove starting dashes
+        .replace(/-*$/,'');             // Remove trailing dashes
+  }
 }

--- a/components/templates/CallToAction.tsx
+++ b/components/templates/CallToAction.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { Button } from '@material-ui/core';
 import { MuiTheme } from '../MuiTheme';
+import { convertTitleToSeoUrl } from './BasePage';
 
 type Props = {
     title: string
@@ -9,16 +10,18 @@ type Props = {
 
 export const CallToActionButtons = function(props: Props) {
     const { title } = props
+    const url = convertTitleToSeoUrl(title)
+
     return (
     <div style={{margin: "60px"}}>
         <Grid container spacing={3} justify="center">
             <Grid item>
-                <Button variant="contained" color="primary" href="/visible-children/paymentForm" size="large">
+                <Button variant="contained" color="primary" href={`/${url}/paymentForm`} size="large">
                     Sponsor a child
                 </Button>
             </Grid>
             <Grid item>
-                <Button variant="outlined" color="primary" size="large" href="/visible-children/about" style={{border:"1px solid", color: MuiTheme.palette.primary.main}}>
+                <Button variant="outlined" color="primary" size="large" href={`/${url}/about`} style={{border:"1px solid", color: MuiTheme.palette.primary.main}}>
                     How "{title}" works?
                 </Button>
             </Grid>

--- a/components/templates/CallToAction.tsx
+++ b/components/templates/CallToAction.tsx
@@ -3,8 +3,12 @@ import Grid from '@material-ui/core/Grid';
 import { Button } from '@material-ui/core';
 import { MuiTheme } from '../MuiTheme';
 
+type Props = {
+    title: string
+  }
 
-export const CallToActionButtons = function() {
+export const CallToActionButtons = function(props: Props) {
+    const { title } = props
     return (
     <div style={{margin: "60px"}}>
         <Grid container spacing={3} justify="center">
@@ -15,7 +19,7 @@ export const CallToActionButtons = function() {
             </Grid>
             <Grid item>
                 <Button variant="outlined" color="primary" size="large" href="/visible-children/about" style={{border:"1px solid", color: MuiTheme.palette.primary.main}}>
-                    How "Your title" works?
+                    How "{title}" works?
                 </Button>
             </Grid>
         </Grid>

--- a/components/templates/CallToAction.tsx
+++ b/components/templates/CallToAction.tsx
@@ -14,7 +14,7 @@ export const CallToActionButtons = function() {
                 </Button>
             </Grid>
             <Grid item>
-                <Button variant="outlined" color="primary" size="large" href="/visible-children/about" style={{border:"1px solid", color: MuiTheme.palette.primary.dark}}>
+                <Button variant="outlined" color="primary" size="large" href="/visible-children/about" style={{border:"1px solid", color: MuiTheme.palette.primary.main}}>
                     How "Your title" works?
                 </Button>
             </Grid>
@@ -33,7 +33,7 @@ export const AboutMongenCallToActionButtons = function() {
                 </Button>
             </Grid>
             <Grid item>
-                <Button variant="outlined" color="primary" size="large" href="/loginOrgMember" style={{border:"1px solid", color: MuiTheme.palette.primary.dark}}>
+                <Button variant="outlined" color="primary" size="large" href="/loginOrgMember" style={{border:"1px solid", color: MuiTheme.palette.primary.main}}>
                     Login to your org profile
                 </Button>
             </Grid>

--- a/pages/[organisationName]/about.tsx
+++ b/pages/[organisationName]/about.tsx
@@ -9,8 +9,6 @@ import {
   import React from "react"
   import { BasePage } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { Organization } from ".";
   
   const useStyles = makeStyles((theme) => ({
     content: {
@@ -33,8 +31,9 @@ import { Organization } from ".";
   
   const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
   const title ="Your title"
+  const organization = ["123"]
 
-  function About({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  function About() {
     const classes = useStyles(organization)
   
     return (
@@ -76,17 +75,17 @@ import { Organization } from ".";
     )
   }
   
-  export const getServerSideProps: GetServerSideProps = async context => {
-    const { organizationName } = context.query
+  // export const getServerSideProps: GetServerSideProps = async context => {
+  //   const { organizationName } = context.query
   
-    const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
-      method: "GET",
-    })
-    const organization: Organization[] = await orgReq.json()
+  //   const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
+  //     method: "GET",
+  //   })
+  //   const organization: Organization[] = await orgReq.json()
   
-    return {
-      props: { organization },
-    }
-  }
+  //   return {
+  //     props: { organization },
+  //   }
+  // }
   
   export default About

--- a/pages/[organisationName]/about.tsx
+++ b/pages/[organisationName]/about.tsx
@@ -9,9 +9,11 @@ import {
   import React from "react"
   import { BasePage } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { Organization } from ".";
   
   const useStyles = makeStyles((theme) => ({
-    heroContent: {
+    content: {
       backgroundColor: theme.palette.background.paper,
       padding: theme.spacing(8, 0, 6),
     },
@@ -20,7 +22,7 @@ import { Footer } from "../../components/templates/Footer";
       padding: theme.spacing(6),
     },
     infoText: {
-      marginTop: "15px",
+      marginTop: "30px",
       fontWeight:300,
     },
     rootLight: {
@@ -29,46 +31,62 @@ import { Footer } from "../../components/templates/Footer";
     },
   }));
   
-    
-  function About() {
-    const classes = useStyles()  
+  const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
+  const title ="Your title"
+
+  function About({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+    const classes = useStyles(organization)
   
     return (
         <NoSsr>
-          <BasePage className={classes.rootLight}>
+          <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | About us</title>
-             {/* Hero unit */}
-             <div className={classes.heroContent}>
+          {organization ? (
+            <div className={classes.content}>
             <Container>
               <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> About Us
               </Typography>
               <Typography variant="h5" align="center" color="textSecondary" paragraph>
-              We’re on a mission to address the societal challenge of street children.
+                {infoText}
               </Typography>
               <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Mission
               </Typography>
               <Typography variant="h5" align="center" color="textSecondary" paragraph>
-                Information about your organization. Information about your organization. Information about your organization. Information about your organization.
+                {infoText}
               </Typography>
               <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Values
               </Typography>
               <Typography variant="h5" align="center" color="textSecondary" paragraph>
-              Information about your organization. Information about your organization. Information about your organization. Information about your organization.
-              Information about your organization. Information about your organization. Information about your organization. Information about your organization.
-             </Typography>
+                {infoText}
+              </Typography>
              <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Story
               </Typography>
               <Typography variant="h5" align="center" color="textSecondary" paragraph>
-              Information about your organization. Information about your organization. Information about your organization. Information about your organization. 
-              Information about your organization. Information about your organization. Information about your organization. Information about your organization. 
-              Information about your organization. Information about your organization. Information about your organization. Information about your organization.              
-            </Typography>
+                {infoText}
+              </Typography>
             </Container>
           </div>
+          ) : (
+            <h1>There is no organization with such name</h1>
+          )}
           </BasePage>
+          <div style={{marginBottom:"50px"}}></div>
           <Footer />
         </NoSsr>
     )
+  }
+  
+  export const getServerSideProps: GetServerSideProps = async context => {
+    const { organizationName } = context.query
+  
+    const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
+      method: "GET",
+    })
+    const organization: Organization[] = await orgReq.json()
+  
+    return {
+      props: { organization },
+    }
   }
   
   export default About

--- a/pages/[organisationName]/about.tsx
+++ b/pages/[organisationName]/about.tsx
@@ -89,3 +89,4 @@ import { Footer } from "../../components/templates/Footer";
   // }
   
   export default About
+  

--- a/pages/[organisationName]/child.tsx
+++ b/pages/[organisationName]/child.tsx
@@ -6,7 +6,7 @@ import {
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
-  import { BasePage, CallToActionButtons } from "../../components/templates"
+  import { BasePage, CallToActionButtons, convertTitleToSeoUrl } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer";
   
   const useStyles = makeStyles((theme) => ({
@@ -81,7 +81,8 @@ import { Footer } from "../../components/templates/Footer";
 
   function Child() {
     const classes = useStyles(children)
-  
+    const url = convertTitleToSeoUrl(title)
+
     return (
         <NoSsr>
           <BasePage className={classes.rootLight} title={title}>
@@ -95,7 +96,7 @@ import { Footer } from "../../components/templates/Footer";
                         className={classes.image}
                         focusVisibleClassName={classes.focusVisible}
                         style={{height: "350px", width: "55%", marginLeft: "25%"}}
-                        href ="/visible-children/paymentForm"
+                        href={`/${url}/paymentForm`}
                         >
                             <span
                                 className={classes.imageSrc}

--- a/pages/[organisationName]/child.tsx
+++ b/pages/[organisationName]/child.tsx
@@ -8,6 +8,8 @@ import {
   import React from "react"
   import { BasePage, CallToActionButtons } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { Children } from ".";
   
   const useStyles = makeStyles((theme) => ({
     cardGrid: {
@@ -60,24 +62,32 @@ import { Footer } from "../../components/templates/Footer";
         backgroundSize: 'cover',
         backgroundPosition: 'center 40%',
       },
+      textTitle: {
+        marginTop: "50px",
+      },
+      textInfo: {
+        marginTop: "50px",
+        fontStyle:"italic",
+      },
   }));
   
-  export interface Children {
-  }
-
   const image = 
     {
       url: '/child.jpg',
       title: 'Child 1',
     };
-    
-  function Child() {
-    const classes = useStyles()  
+
+  const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
+  const title = "Your title"
+
+  function Child({ children }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+    const classes = useStyles(children)
   
     return (
         <NoSsr>
-          <BasePage className={classes.rootLight}>
+          <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | Child details</title>
+          {children ? (
           <Container className={classes.cardGrid}>
             {/* End hero unit */}
                     <ButtonBase
@@ -95,81 +105,76 @@ import { Footer } from "../../components/templates/Footer";
                                 }}
                             />
                     </ButtonBase>
-                  <CallToActionButtons/>
-                  <Typography component="h2" variant="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
+                  <CallToActionButtons title={title}/>
+                  <Typography component="h2" variant="h3" align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
                     Information about "Child 1"
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <div style={{paddingLeft:"80px", paddingRight:"80px"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Name and Surname:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Location:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Date of birth, gender, state of origin:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
-                    Fear/trauma:
-                  </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
-                  </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Skills and strengths:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Reason for child being on the street:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textTitle} style={{fontStyle:"italic"}}>
                     Last school attended, last class stopped:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <Typography component="h3" align="center" color="textPrimary" gutterBottom style={{marginTop:"50px", fontStyle:"italic"}}>
+                  <Typography component="h3" align="center" color="textPrimary" gutterBottom className={classes.textInfo}>
                     Name, phone and address of the parent/ward:
                   </Typography>
-                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom style={{marginTop:"50px"}}>
-                   Information about the child. Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. 
-                    Information about the child. Information about the child. Information about the child. Information about the child. 
+                  <Typography component="h3"  align="center" color="textPrimary" gutterBottom className={classes.textTitle}>
+                    {infoText}
                   </Typography>
-                  <CallToActionButtons/>
+                  </div>
+                  <CallToActionButtons title={title}/>
           </Container>
+          ) : (
+            <h1>Sorry, we can't display the info about this child now. Come back later, we are working hard to fix the issue!</h1>
+          )}
             <Footer />
           </BasePage>
         </NoSsr>
     )
   }
 
-  export default Child
+  export const getServerSideProps: GetServerSideProps = async context => {
+    const { childId } = context.query
   
+    const childReq = await fetch(`http://localhost:8080/api/v1/${childId}`, {
+      method: "GET",
+    })
+    const children: Children[] = await childReq.json()
+  
+    return {
+      props: { children },
+    }
+  }
+  
+  export default Child  

--- a/pages/[organisationName]/child.tsx
+++ b/pages/[organisationName]/child.tsx
@@ -8,8 +8,6 @@ import {
   import React from "react"
   import { BasePage, CallToActionButtons } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { Children } from ".";
   
   const useStyles = makeStyles((theme) => ({
     cardGrid: {
@@ -79,8 +77,9 @@ import { Children } from ".";
 
   const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
   const title = "Your title"
+  const children = "123"
 
-  function Child({ children }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  function Child() {
     const classes = useStyles(children)
   
     return (
@@ -164,17 +163,17 @@ import { Children } from ".";
     )
   }
 
-  export const getServerSideProps: GetServerSideProps = async context => {
-    const { childId } = context.query
+  // export const getServerSideProps: GetServerSideProps = async context => {
+  //   const { childId } = context.query
   
-    const childReq = await fetch(`http://localhost:8080/api/v1/${childId}`, {
-      method: "GET",
-    })
-    const children: Children[] = await childReq.json()
+  //   const childReq = await fetch(`http://localhost:8080/api/v1/${childId}`, {
+  //     method: "GET",
+  //   })
+  //   const children: Children[] = await childReq.json()
   
-    return {
-      props: { children },
-    }
-  }
+  //   return {
+  //     props: { children},
+  //   }
+  // }
   
   export default Child  

--- a/pages/[organisationName]/index.tsx
+++ b/pages/[organisationName]/index.tsx
@@ -16,6 +16,7 @@ import React from "react"
 import { BasePage, CallToActionButtons } from "../../components/templates"
 import { MuiTheme } from "../../components/MuiTheme"
 import { Footer } from "../../components/templates/Footer"
+import { InferGetServerSidePropsType, GetServerSideProps } from "next"
 
 const useStyles = makeStyles((theme) => ({
   heroContent: {
@@ -46,67 +47,93 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export interface Homepage {
+export interface Organization {
+  id: any
+  address: any
+  country: any
+  name: any
+  verified: any
+  mission: any
+  vision: any
 }
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-function Index() {
-  const classes = useStyles()  
+function Index({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const classes = useStyles(organization)
 
   return (
       <NoSsr>
         <BasePage className={classes.rootLight}>
         <title>Mongen Initiative</title>
-           <div>
-          <Container maxWidth="sm" className={classes.heroContent}>
-            <Typography component="h1" variant="h2" align="center" color="textPrimary" gutterBottom >
-              Your title
-            </Typography>
-            <Typography style={{fontSize: "1.8em"}} align="center" color="textSecondary">
-               Information about your organization. You can add/change in your org profile. 
-               Information about your organization. You can add/change in your org profile. 
-               Information about your organization. You can add/change in your org profile.
-            </Typography>
-          </Container>
-        </div>
-        <CallToActionButtons/>
-        <Divider />
-        <Container className={classes.cardGrid} maxWidth="md">
-          <Grid container spacing={4}>
-            {cards.map((card) => (
-              <Grid item key={card} xs={12} sm={6} md={4}>
-                <Link href="/child" underline="none">
-                  <Card className={classes.card}>
-                    <CardMedia
-                      className={classes.cardMedia}
-                      image="child.jpg"
-                      title="Image title"
-                    />
-                    <CardContent className={classes.cardContent}>
-                      <Typography gutterBottom variant="h5" component="h2">
-                        A child
-                      </Typography>
-                      <Typography>
-                        This is a child that needs your help. You can use this section to put some key info about the child.
-                      </Typography>
-                    </CardContent>
-                    <CardActions>
-                      <Button size="small"  href="/child" style={{color: MuiTheme.palette.primary.dark}}>
-                        Learn more
-                      </Button>
-                    </CardActions>
-                  </Card>
-                </Link>
-              </Grid>
-            ))}
-          </Grid>
-        </Container>
-        <CallToActionButtons/>
-          <Footer />
+        {organization ? (
+            <div>
+              <div>
+              <Container maxWidth="sm" className={classes.heroContent}>
+                <Typography component="h1" variant="h2" align="center" color="textPrimary" gutterBottom >
+                  Your title {organization.name}
+                </Typography>
+                <Typography style={{fontSize: "1.8em"}} align="center" color="textSecondary">
+                  Information about your organization. You can add/change in your org profile. 
+                  Information about your organization. You can add/change in your org profile. 
+                  Information about your organization. You can add/change in your org profile.
+                </Typography>
+              </Container>
+              </div>
+              <CallToActionButtons/>
+              <Divider />
+                <Container className={classes.cardGrid} maxWidth="md">
+                  <Grid container spacing={4}>
+                    {cards.map((card) => (
+                      <Grid item key={card} xs={12} sm={6} md={4}>
+                        <Link href="visible-children/child" underline="none">
+                          <Card className={classes.card}>
+                            <CardMedia
+                              className={classes.cardMedia}
+                              image="child.jpg"
+                              title="Image title"
+                            />
+                            <CardContent className={classes.cardContent}>
+                              <Typography gutterBottom variant="h5" component="h2">
+                                A child
+                              </Typography>
+                              <Typography>
+                                This is a child that needs your help. You can use this section to put some key info about the child.
+                              </Typography>
+                            </CardContent>
+                            <CardActions>
+                              <Button size="small"  href="visible-children/child" style={{color: MuiTheme.palette.primary.main}}>
+                                Learn more
+                              </Button>
+                            </CardActions>
+                          </Card>
+                        </Link>
+                      </Grid>
+                    ))}
+                  </Grid>
+                </Container>
+              <CallToActionButtons/>
+              <Footer />
+            </div>
+        ) : (
+          <h1>There is no organization with such name</h1>
+        )}
         </BasePage>
       </NoSsr>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const { organizationName } = context.query
+
+  const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
+    method: "GET",
+  })
+  const organization: Organization[] = await orgReq.json()
+
+  return {
+    props: { organization },
+  }
 }
 
 export default Index

--- a/pages/[organisationName]/index.tsx
+++ b/pages/[organisationName]/index.tsx
@@ -16,7 +16,6 @@ import React from "react"
 import { BasePage, CallToActionButtons } from "../../components/templates"
 import { MuiTheme } from "../../components/MuiTheme"
 import { Footer } from "../../components/templates/Footer"
-import { InferGetServerSidePropsType, GetServerSideProps } from "next"
 
 const useStyles = makeStyles((theme) => ({
   heroContent: {
@@ -59,12 +58,16 @@ export interface Organization {
 export interface Children {
   id: any
 }
+export interface Sponsor {
+  id: any
+}
 
 const children = ["Child 1", "Child 2", "Child 3", "Child 4", "Child 5", "Child 6", "Child 7", "Child 8", "Child 9"];
 const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
 const title = "Your title"
+const organization = ["123"]
 
-function Index({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function Index() {
   const classes = useStyles(organization)
 
   return (
@@ -126,17 +129,17 @@ function Index({ organization }: InferGetServerSidePropsType<typeof getServerSid
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async context => {
-  const { organizationName } = context.query
+// export const getServerSideProps: GetServerSideProps = async context => {
+//   const { organizationName } = context.query
 
-  const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
-    method: "GET",
-  })
-  const organization: Organization[] = await orgReq.json()
+//   const orgReq = await fetch(`http://localhost:8080/api/v1/${organizationName}`, {
+//     method: "GET",
+//   })
+//   const organization: Organization[] = await orgReq.json()
 
-  return {
-    props: { organization },
-  }
-}
+//   return {
+//     props: { organization },
+//   }
+// }
 
 export default Index

--- a/pages/[organisationName]/index.tsx
+++ b/pages/[organisationName]/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "@material-ui/core"
 import { makeStyles } from "@material-ui/core/styles"
 import React from "react"
-import { BasePage, CallToActionButtons } from "../../components/templates"
+import { BasePage, CallToActionButtons, convertTitleToSeoUrl } from "../../components/templates"
 import { MuiTheme } from "../../components/MuiTheme"
 import { Footer } from "../../components/templates/Footer"
 
@@ -69,6 +69,7 @@ const organization = ["123"]
 
 function Index() {
   const classes = useStyles(organization)
+  const url = convertTitleToSeoUrl(title)
 
   return (
       <NoSsr>
@@ -92,7 +93,7 @@ function Index() {
                   <Grid container spacing={4}>
                     {children.map((child) => (
                       <Grid item key={child} xs={12} sm={6} md={4}>
-                        <Link href="visible-children/child" underline="none">
+                        <Link href={`/${url}/child`} underline="none">
                           <Card className={classes.card}>
                             <CardMedia
                               className={classes.cardMedia}
@@ -108,7 +109,7 @@ function Index() {
                               </Typography>
                             </CardContent>
                             <CardActions>
-                              <Button size="small"  href="visible-children/child" style={{color: MuiTheme.palette.primary.main}}>
+                              <Button size="small"  href={`/${url}/child`} style={{color: MuiTheme.palette.primary.main}}>
                                 Learn more
                               </Button>
                             </CardActions>

--- a/pages/[organisationName]/index.tsx
+++ b/pages/[organisationName]/index.tsx
@@ -56,36 +56,39 @@ export interface Organization {
   mission: any
   vision: any
 }
+export interface Children {
+  id: any
+}
 
-const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const children = ["Child 1", "Child 2", "Child 3", "Child 4", "Child 5", "Child 6", "Child 7", "Child 8", "Child 9"];
+const infoText = "Information about the child. Information about the child. Information about the child. \n Information about the child. Information about the child. Information about the child. Information about the child.  \n Information about the child. Information about the child. Information about the child. Information about the child."
+const title = "Your title"
 
 function Index({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const classes = useStyles(organization)
 
   return (
       <NoSsr>
-        <BasePage className={classes.rootLight}>
+        <BasePage className={classes.rootLight} title={title}>
         <title>Mongen Initiative</title>
         {organization ? (
             <div>
               <div>
               <Container maxWidth="sm" className={classes.heroContent}>
                 <Typography component="h1" variant="h2" align="center" color="textPrimary" gutterBottom >
-                  Your title {organization.name}
+                  {title}
                 </Typography>
                 <Typography style={{fontSize: "1.8em"}} align="center" color="textSecondary">
-                  Information about your organization. You can add/change in your org profile. 
-                  Information about your organization. You can add/change in your org profile. 
-                  Information about your organization. You can add/change in your org profile.
+                  {infoText}
                 </Typography>
               </Container>
               </div>
-              <CallToActionButtons/>
+              <CallToActionButtons title={title}/>
               <Divider />
                 <Container className={classes.cardGrid} maxWidth="md">
                   <Grid container spacing={4}>
-                    {cards.map((card) => (
-                      <Grid item key={card} xs={12} sm={6} md={4}>
+                    {children.map((child) => (
+                      <Grid item key={child} xs={12} sm={6} md={4}>
                         <Link href="visible-children/child" underline="none">
                           <Card className={classes.card}>
                             <CardMedia
@@ -95,7 +98,7 @@ function Index({ organization }: InferGetServerSidePropsType<typeof getServerSid
                             />
                             <CardContent className={classes.cardContent}>
                               <Typography gutterBottom variant="h5" component="h2">
-                                A child
+                                {child}
                               </Typography>
                               <Typography>
                                 This is a child that needs your help. You can use this section to put some key info about the child.
@@ -112,7 +115,7 @@ function Index({ organization }: InferGetServerSidePropsType<typeof getServerSid
                     ))}
                   </Grid>
                 </Container>
-              <CallToActionButtons/>
+              <CallToActionButtons title={title}/>
               <Footer />
             </div>
         ) : (

--- a/pages/[organisationName]/newRecord.tsx
+++ b/pages/[organisationName]/newRecord.tsx
@@ -71,6 +71,8 @@ function getStepContent(step) {
   }
 }
 
+const title = "Your title"
+
 export default function AddNewRecord() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -85,7 +87,7 @@ export default function AddNewRecord() {
 
   return (
       <NoSsr>
-        <BasePage className={classes.rootLight}>
+        <BasePage className={classes.rootLight} title={title}>
         <title>Mongen | Add a new child</title>
           <Container className={classes.layout}>
             <Paper className={classes.paper}>

--- a/pages/[organisationName]/orgProfile.tsx
+++ b/pages/[organisationName]/orgProfile.tsx
@@ -36,13 +36,14 @@ import {DropzoneArea} from 'material-ui-dropzone'
     },
   }));
   
-    
+  const title = "Your title"
+  
   function OrgProfile() {
     const classes = useStyles()  
   
     return (
         <NoSsr>
-          <BasePage className={classes.rootLight}>
+          <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | Organization profile </title>
              {/* Hero unit */}
              <div className={classes.heroContent}>
@@ -74,7 +75,6 @@ import {DropzoneArea} from 'material-ui-dropzone'
         </Container>
           </div>
           </BasePage>
-          <Footer />
         </NoSsr>
     )
   }

--- a/pages/[organisationName]/orgProfile.tsx
+++ b/pages/[organisationName]/orgProfile.tsx
@@ -10,7 +10,6 @@ import {
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
   import { BasePage } from "../../components/templates"
-import { Footer } from "../../components/templates/Footer";
 import {DropzoneArea} from 'material-ui-dropzone'
 
   const useStyles = makeStyles((theme) => ({

--- a/pages/[organisationName]/paymentForm.tsx
+++ b/pages/[organisationName]/paymentForm.tsx
@@ -84,10 +84,12 @@ export default function Checkout() {
   const handleBack = () => {
     setActiveStep(activeStep - 1);
   };
+  
+  const title = "Your title"
 
   return (
     <NoSsr>
-      <BasePage className={classes.rootLight}>
+      <BasePage className={classes.rootLight} title={title}>
       <title>Mongen | Sponsor a child</title>
         <Container className={classes.layout}>
           <Paper className={classes.paper}>

--- a/pages/[organisationName]/sponsorProfile.tsx
+++ b/pages/[organisationName]/sponsorProfile.tsx
@@ -11,7 +11,7 @@ import {
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
-  import { BasePage } from "../../components/templates"
+  import { BasePage, convertTitleToSeoUrl } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer"
 import { MuiTheme } from "../../components/MuiTheme"
 
@@ -50,16 +50,17 @@ import { MuiTheme } from "../../components/MuiTheme"
  
   const children = [1, 2];
   const title = "Your title"
-  const sponsors = ["123"]
+  const sponsor = ["123"]
 
   function SponsorProfile() {
-    const classes = useStyles(sponsors)
-  
+    const classes = useStyles(sponsor)
+    const url = convertTitleToSeoUrl(title)
+
     return (
         <NoSsr>
           <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | Sponsor's profile</title>
-          {sponsors ? (
+          {sponsor ? (
             <div className={classes.heroContent}>
               <Container>
                 <Typography  variant="h3" align="center" color="textPrimary" gutterBottom style={{marginTop: "15px", fontWeight:300}}> Hello, hero!
@@ -83,7 +84,7 @@ import { MuiTheme } from "../../components/MuiTheme"
                       <Button href="#" variant="contained" color="primary" size="large" className={classes.buttons}> Check how you helped this month</Button>
                       <Button href="#" variant="contained" size="large" color="primary" className={classes.buttons}> Check full report </Button>
                       <Button href="#" variant="contained" color="primary" size="large" className={classes.buttons}> Change notification settings </Button>
-                      <Button href="/visible-children/child" variant="outlined" size="large" className={classes.buttons} style = {{border:"1px solid", color: MuiTheme.palette.primary.main}}> Read about the child </Button>
+                      <Button href={`/${url}/child`} variant="outlined" size="large" className={classes.buttons} style = {{border:"1px solid", color: MuiTheme.palette.primary.main}}> Read about the child </Button>
                       </CardContent>
                     </Card>
                   </div> 

--- a/pages/[organisationName]/sponsorProfile.tsx
+++ b/pages/[organisationName]/sponsorProfile.tsx
@@ -14,12 +14,14 @@ import {
   import { BasePage } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer"
 import { MuiTheme } from "../../components/MuiTheme"
+import { InferGetServerSidePropsType, GetServerSideProps } from "next"
+import { Sponsor } from "."
 
   const useStyles = makeStyles((theme) => ({
     heroContent: {
       backgroundColor: theme.palette.background.paper,
       padding: theme.spacing(8, 0, 6),
-      width: "100%"
+      width: "100%",
     },
     card: {
       height: '100%',
@@ -42,41 +44,47 @@ import { MuiTheme } from "../../components/MuiTheme"
       display:"flex",
       color: theme.palette.secondary.light,
     },
+    buttons: {
+      marginTop:"8%",
+      width: "100%",
+    },
   }));
  
-  const cards = [1, 2];
-    
-  function SponsorProfile() {
-    const classes = useStyles()  
+  const children = [1, 2];
+  const title = "Your title"
+
+  function SponsorProfile({ sponsor }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+    const classes = useStyles(sponsor)
   
     return (
         <NoSsr>
-          <BasePage className={classes.rootLight}>
+          <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | Sponsor's profile</title>
+          {sponsor ? (
             <div className={classes.heroContent}>
               <Container>
                 <Typography  variant="h3" align="center" color="textPrimary" gutterBottom style={{marginTop: "15px", fontWeight:300}}> Hello, hero!
                 </Typography>
-                <Typography variant="h6" align="center" color="textSecondary" paragraph>
-                Thank you for your contributions, you are doing a great job!
+                <Typography variant="h6" align="center" color="textSecondary" paragraph style={{fontStyle:"italic"}}>
+                Thank you for your contributions, you are doing a great job! 
+                </Typography>
+                <Typography variant="h6" align="center" color="textSecondary" paragraph >
+                You can review the reports and other info about your contributions on this page
                 </Typography>
                   <div>
-                    <div >
-                      <Typography  variant="h4" align="center" color="textPrimary" gutterBottom style={{marginTop: "5%", fontWeight:300}}> Your donations: </Typography>
-                  </div>
-                  {cards.map((card) => (
-                  <div style={{width:"30%", float: "left", marginTop:"10%", marginLeft: "10%"}} key={card}>
+                  {children.map((child) => (
+                  <div style={{width:"30%", float: "left", marginTop:"10%", marginLeft: "10%"}} key={child}>
                     <Card className={classes.card}>
                       <CardMedia
                         className={classes.cardMedia}
-                        image="child.jpg"
+                        image="/child.jpg"
                         title="Image title"
                       />
                       <CardContent className={classes.cardContent}>
-                      <Button variant="contained" color="primary" size="large" style = {{marginTop:"8%", width: "100%"}}> Check how you helped this month</Button>
-                      <Button variant="contained" size="large" color="primary" style = {{marginTop:"8%", width: "100%"}}> Check full report </Button>
-                      <Button variant="contained" color="primary" size="large" style = {{marginTop:"8%", width: "100%"}}> Check donation reminders </Button>
-                      <Button variant="outlined" size="large" style = {{marginTop:"8%", width: "100%", border:"1px solid", color: MuiTheme.palette.primary.main}}> Read about the child </Button>
+                      <Button href="#" variant="contained" color="primary" size="large" className={classes.buttons}> Check how you helped this month</Button>
+                      <Button href="#" variant="contained" size="large" color="primary" className={classes.buttons}> Check full report </Button>
+                      <Button href="#" variant="contained" color="primary" size="large" className={classes.buttons}> Change notification settings </Button>
+                      <Button href="/visible-children/child" variant="outlined" size="large" className={classes.buttons} style = {{border:"1px solid", color: MuiTheme.palette.primary.main}}> Read about the child </Button>
                       </CardContent>
                     </Card>
                   </div> 
@@ -84,10 +92,28 @@ import { MuiTheme } from "../../components/MuiTheme"
                   </div>
               </Container>
             </div>
+             ) : (
+              <h1>Sorry, we can't display the info about your donations now. Come back later, we are working hard to fix the issue!</h1>
+              )}
           </BasePage>
+        {/* a bit of space between cards and footer */}
+          <div style={{marginBottom:"150px"}}></div> 
           <Footer />
         </NoSsr>
     )
+  }
+  
+  export const getServerSideProps: GetServerSideProps = async context => {
+    const { sponsorId } = context.query
+  
+    const sponsorReq = await fetch(`http://localhost:8080/api/v1/${sponsorId}`, {
+      method: "GET",
+    })
+    const sponsor: Sponsor[] = await sponsorReq.json()
+  
+    return {
+      props: { sponsor },
+    }
   }
   
   export default SponsorProfile

--- a/pages/[organisationName]/sponsorProfile.tsx
+++ b/pages/[organisationName]/sponsorProfile.tsx
@@ -14,8 +14,6 @@ import {
   import { BasePage } from "../../components/templates"
 import { Footer } from "../../components/templates/Footer"
 import { MuiTheme } from "../../components/MuiTheme"
-import { InferGetServerSidePropsType, GetServerSideProps } from "next"
-import { Sponsor } from "."
 
   const useStyles = makeStyles((theme) => ({
     heroContent: {
@@ -52,15 +50,16 @@ import { Sponsor } from "."
  
   const children = [1, 2];
   const title = "Your title"
+  const sponsors = ["123"]
 
-  function SponsorProfile({ sponsor }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-    const classes = useStyles(sponsor)
+  function SponsorProfile() {
+    const classes = useStyles(sponsors)
   
     return (
         <NoSsr>
           <BasePage className={classes.rootLight} title={title}>
           <title>Mongen | Sponsor's profile</title>
-          {sponsor ? (
+          {sponsors ? (
             <div className={classes.heroContent}>
               <Container>
                 <Typography  variant="h3" align="center" color="textPrimary" gutterBottom style={{marginTop: "15px", fontWeight:300}}> Hello, hero!
@@ -103,17 +102,17 @@ import { Sponsor } from "."
     )
   }
   
-  export const getServerSideProps: GetServerSideProps = async context => {
-    const { sponsorId } = context.query
+  // export const getServerSideProps: GetServerSideProps = async context => {
+  //   const { sponsorId } = context.query
   
-    const sponsorReq = await fetch(`http://localhost:8080/api/v1/${sponsorId}`, {
-      method: "GET",
-    })
-    const sponsor: Sponsor[] = await sponsorReq.json()
+  //   const sponsorReq = await fetch(`http://localhost:8080/api/v1/${sponsorId}`, {
+  //     method: "GET",
+  //   })
+  //   const sponsor: Sponsor[] = await sponsorReq.json()
   
-    return {
-      props: { sponsor },
-    }
-  }
+  //   return {
+  //     props: { sponsor },
+  //   }
+  // }
   
   export default SponsorProfile

--- a/pages/[organisationName]/sponsorProfile.tsx
+++ b/pages/[organisationName]/sponsorProfile.tsx
@@ -76,7 +76,7 @@ import { MuiTheme } from "../../components/MuiTheme"
                       <Button variant="contained" color="primary" size="large" style = {{marginTop:"8%", width: "100%"}}> Check how you helped this month</Button>
                       <Button variant="contained" size="large" color="primary" style = {{marginTop:"8%", width: "100%"}}> Check full report </Button>
                       <Button variant="contained" color="primary" size="large" style = {{marginTop:"8%", width: "100%"}}> Check donation reminders </Button>
-                      <Button variant="outlined" size="large" style = {{marginTop:"8%", width: "100%", border:"1px solid", color: MuiTheme.palette.primary.dark}}> Read about the child </Button>
+                      <Button variant="outlined" size="large" style = {{marginTop:"8%", width: "100%", border:"1px solid", color: MuiTheme.palette.primary.main}}> Read about the child </Button>
                       </CardContent>
                     </Card>
                   </div> 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles((theme) => ({
   },
   rootLight: {
     flexGrow: 1,
-    color: theme.palette.secondary.light,
   },
 }));
 
@@ -77,7 +76,7 @@ function Index() {
           <Grid container spacing={4}>
             {cards.map((card) => (
               <Grid item key={card} xs={12} sm={6} md={4}>
-                <Link href="/child" underline="none">
+                <Link href="/visible-children" underline="none">
                   <Card className={classes.card}>
                     <CardMedia
                       className={classes.cardMedia}
@@ -93,7 +92,7 @@ function Index() {
                       </Typography>
                     </CardContent>
                     <CardActions>
-                      <Button size="small"  href="#" style={{color: MuiTheme.palette.primary.dark}}>
+                      <Button size="small" href="/visible-children" style={{color: MuiTheme.palette.primary.main}}>
                         Learn more
                       </Button>
                     </CardActions>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
 export interface Homepage {
 }
 
-const cards = [1, 2, 3, 4, 5, 6];
+const organizations = ["Visible Children", "Organization 1", "Organization 2", "Organization 3", "Organization 4", "Organization 5"]
 
 function Index() {
   const classes = useStyles()  
@@ -65,7 +65,7 @@ function Index() {
             <Typography style={{fontSize: "1.7em", width:"100%"}} align="center" color="textSecondary">
                Mongen Initiative is a volunteering project created by developers: 
               Juan Negrier  <span style={{fontStyle:"italic"}}>(Chile)</span>, Marcelo Negrier <span style={{fontStyle:"italic"}}>(Chile)</span> and Oleksandra Pishcheiko <span style={{fontStyle:"italic"}}>(Ukraine)</span>. 
-               We want to help small charity Organizations to have a place where they can store, access, view their data, 
+               We want to help small charity organizations to have a place, where they can store, access, view their data, 
                and share their great missions with the world!
             </Typography>
           </Container>
@@ -74,8 +74,8 @@ function Index() {
         <Divider />
         <Container className={classes.cardGrid} maxWidth="md">
           <Grid container spacing={4}>
-            {cards.map((card) => (
-              <Grid item key={card} xs={12} sm={6} md={4}>
+            {organizations.map((org) => (
+              <Grid item key={org} xs={12} sm={6} md={4}>
                 <Link href="/visible-children" underline="none">
                   <Card className={classes.card}>
                     <CardMedia
@@ -85,7 +85,7 @@ function Index() {
                     />
                     <CardContent className={classes.cardContent}>
                       <Typography gutterBottom variant="h5" component="h2">
-                        An organization
+                        {org}
                       </Typography>
                       <Typography>
                         This Organization works with us. Click to view their website

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "@material-ui/core"
 import { makeStyles } from "@material-ui/core/styles"
 import React from "react"
-import { BasePageAboutMongen, AboutMongenCallToActionButtons } from "../components/templates"
+import { BasePageAboutMongen, AboutMongenCallToActionButtons, convertTitleToSeoUrl } from "../components/templates"
 import { MuiTheme } from "../components/MuiTheme"
 import { AboutMongenFooter } from "../components/templates/Footer"
 
@@ -52,7 +52,8 @@ const organizations = ["Visible Children", "Organization 1", "Organization 2", "
 
 function Index() {
   const classes = useStyles()  
-
+  const url = convertTitleToSeoUrl(organizations[1])
+  
   return (
       <NoSsr>
         <BasePageAboutMongen className={classes.rootLight}>
@@ -76,7 +77,7 @@ function Index() {
           <Grid container spacing={4}>
             {organizations.map((org) => (
               <Grid item key={org} xs={12} sm={6} md={4}>
-                <Link href="/visible-children" underline="none">
+                <Link href={`/${url}`} underline="none">
                   <Card className={classes.card}>
                     <CardMedia
                       className={classes.cardMedia}
@@ -92,7 +93,7 @@ function Index() {
                       </Typography>
                     </CardContent>
                     <CardActions>
-                      <Button size="small" href="/visible-children" style={{color: MuiTheme.palette.primary.main}}>
+                      <Button size="small" href={`/${url}`} style={{color: MuiTheme.palette.primary.main}}>
                         Learn more
                       </Button>
                     </CardActions>

--- a/pages/loginAdmin.tsx
+++ b/pages/loginAdmin.tsx
@@ -8,7 +8,7 @@ import {
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
-  import { BasePageAboutMongen } from "../components/templates"
+  import { BasePageAboutMongen, convertTitleToSeoUrl } from "../components/templates"
   import { AboutMongenFooter } from "../components/templates/Footer"
   
   const useStyles = makeStyles((theme) => ({
@@ -46,9 +46,12 @@ import {
     },
   }));
     
+  const title = "Your title"
+  
   function LoginAdmin() {
     const classes = useStyles()  
-  
+    const url = convertTitleToSeoUrl(title)
+
     return (
         <NoSsr>
             <BasePageAboutMongen className={classes.rootLight}>
@@ -67,7 +70,7 @@ import {
                         <Paper component="form" style={{width: "60%", padding: '12px 14px', marginTop:"20px", marginLeft:"23%", marginBottom:"30px", alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Password" style={{flex: "1"}} />
                         </Paper>
-                        <Button href="/visible-children/orgProfile" variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
+                        <Button href={`/${url}/orgProfile`} variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
                         <Button style={{display:"block", marginLeft:"22%", marginTop:"40px"}} href="mailto:support@example.com">Don't have an account yet? Contact us</Button>
                 </Container>
                 <AboutMongenFooter />

--- a/pages/loginAdmin.tsx
+++ b/pages/loginAdmin.tsx
@@ -39,6 +39,11 @@ import {
       flexGrow: 1,
       color: theme.palette.secondary.light,
     },
+    button: {
+      marginLeft:"100%",
+      width:"50%",
+      color: theme.palette.primary.main,
+    },
   }));
     
   function LoginAdmin() {
@@ -53,8 +58,8 @@ import {
                     Login as an admin
                     </Typography>
                         <div>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}} href="/loginOrgMember">Log in as org member</Button>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}}  href="/loginSponsor">Log in as a sponsor</Button>
+                        <Button  className={classes.button} href="/loginOrgMember">Log in as org member</Button>
+                        <Button className={classes.button}  href="/loginSponsor">Log in as a sponsor</Button>
                         </div>
                         <Paper component="form" style={{width: "60%", padding: '12px 14px',  marginLeft:"23%",  alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Username" style={{flex: "1"}} />

--- a/pages/loginOrgMember.tsx
+++ b/pages/loginOrgMember.tsx
@@ -39,6 +39,11 @@ import {
       flexGrow: 1,
       color: theme.palette.secondary.light,
     },
+    button: {
+      marginLeft:"100%",
+      width:"50%",
+      color: theme.palette.primary.main,
+    },
   }));
     
   function LoginOrgMember() {
@@ -53,8 +58,8 @@ import {
                     Login as an org member
                     </Typography>
                         <div>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}} href="/loginAdmin">Log in as an administrator</Button>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}} href="/loginSponsor">Log in as a sponsor</Button>
+                        <Button className={classes.button} href="/loginAdmin">Log in as an administrator</Button>
+                        <Button className={classes.button} href="/loginSponsor">Log in as a sponsor</Button>
                         </div>
                         <Paper component="form" style={{width: "60%", padding: '12px 14px',  marginLeft:"23%",  alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Username" style={{flex: "1"}} />

--- a/pages/loginOrgMember.tsx
+++ b/pages/loginOrgMember.tsx
@@ -8,7 +8,7 @@ import {
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
-  import { BasePageAboutMongen } from "../components/templates"
+  import { BasePageAboutMongen, convertTitleToSeoUrl } from "../components/templates"
   import { AboutMongenFooter } from "../components/templates/Footer"
   
   const useStyles = makeStyles((theme) => ({
@@ -46,9 +46,12 @@ import {
     },
   }));
     
+  const title = "Your title"
+
   function LoginOrgMember() {
     const classes = useStyles()  
-  
+    const url = convertTitleToSeoUrl(title)
+
     return (
         <NoSsr>
             <BasePageAboutMongen className={classes.rootLight}>
@@ -67,7 +70,7 @@ import {
                         <Paper component="form" style={{width: "60%", padding: '12px 14px', marginTop:"20px", marginLeft:"23%", marginBottom:"30px", alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Password" style={{flex: "1"}} />
                         </Paper>
-                        <Button href="/visible-children/newRecord" variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
+                        <Button href={`/${url}/newRecord`} variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
                         <Button style={{display:"block", marginLeft:"22%", marginTop:"40px"}} href="mailto:support@example.com">Don't have an account yet? Contact us</Button>
                 </Container>
                 <AboutMongenFooter />

--- a/pages/loginSponsor.tsx
+++ b/pages/loginSponsor.tsx
@@ -8,7 +8,7 @@ import {
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
-  import { BasePageAboutMongen } from "../components/templates"
+  import { BasePageAboutMongen, convertTitleToSeoUrl } from "../components/templates"
   import { AboutMongenFooter } from "../components/templates/Footer"
   
   const useStyles = makeStyles((theme) => ({
@@ -45,10 +45,13 @@ import {
       color: theme.palette.primary.main,
     },
   }));
-    
+  
+  const title = "Your title"
+
   function LoginSponsor() {
     const classes = useStyles()  
-  
+    const url = convertTitleToSeoUrl(title)
+
     return (
         <NoSsr>
             <BasePageAboutMongen className={classes.rootLight}>
@@ -67,7 +70,7 @@ import {
                         <Paper component="form" style={{width: "60%", padding: '12px 14px', marginTop:"20px", marginLeft:"23%", marginBottom:"30px", alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Password" style={{flex: "1"}} />
                         </Paper>
-                        <Button href="/visible-children/sponsorProfile" variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
+                        <Button href={`/${url}/sponsorProfile`} variant="outlined"  color="primary" style={{width:"30%", display:"block", marginLeft:"36%", marginTop:"40px", paddingLeft:"10%"}} size="large" >Sign In</Button>
                         <Button style={{display:"block", marginLeft:"22%", marginTop:"40px"}} href="mailto:support@example.com">Don't have an account yet? Contact us</Button>
                 </Container>
                 <AboutMongenFooter />

--- a/pages/loginSponsor.tsx
+++ b/pages/loginSponsor.tsx
@@ -39,6 +39,11 @@ import {
       flexGrow: 1,
       color: theme.palette.secondary.light,
     },
+    button: {
+      marginLeft:"100%",
+      width:"50%",
+      color: theme.palette.primary.main,
+    },
   }));
     
   function LoginSponsor() {
@@ -53,8 +58,8 @@ import {
                     Login as a sponsor
                     </Typography>
                         <div>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}} href="/loginOrgMember">Log in as org member</Button>
-                        <Button style={{ marginLeft:"100%", width:"50%", color:"#4e9025"}} href="/loginAdmin">Log in as an admin</Button>
+                        <Button className={classes.button} href="/loginOrgMember">Log in as org member</Button>
+                        <Button className={classes.button} href="/loginAdmin">Log in as an admin</Button>
                         </div>
                         <Paper component="form" style={{width: "60%", padding: '12px 14px',  marginLeft:"23%",  alignItems: 'center', display: 'flex'}}> 
                             <InputBase placeholder="Username" style={{flex: "1"}} />


### PR DESCRIPTION
Small improvements:

- colours change
- small refactoring: adding some parameters instead of hard coding to then faster convert to using server side props. Also adding a function that converts the title to seo url. I think we should do it on the python level, but for now keeping it here.
Since I need the org title everywhere, would be cool to have the url and the title provided from the backend. 

Note, to access mongen homepage, go to `localhost:3000/`. To access org profile, go to `localhost:3000/visible-children/`

- homepage (no footer to distinguish)
<img width="297" alt="Screenshot 2021-01-06 at 18 53 40" src="https://user-images.githubusercontent.com/44492659/103808859-89891400-5050-11eb-9acb-99fff46e9f92.png">
- org page. Further down the line they will be able to choose colours, probably
<img width="420" alt="Screenshot 2021-01-06 at 18 54 42" src="https://user-images.githubusercontent.com/44492659/103808938-a58cb580-5050-11eb-82e2-1e3e2ad5e974.png">

