### PR TITLE
Small enhancements 

### DIFF
--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -77,17 +77,17 @@ export const BasePage = function(props: Props) {
               <Typography>
                 <Link
                   underline="none"
-                  href={`/${orgId}/payment`}
+                  href={`/${orgId}/help`}
                   className={classes.titleLight}
                 >
                   Get involved
                 </Link>
               </Typography>
             </div>
-            <div style={{ float: "left", backgroundColor: `${MuiTheme.palette.primary.main}`, marginLeft:"20%", width:"100px" }}>
+            <div style={{ float: "left", backgroundColor: `${MuiTheme.palette.primary.main}`, marginLeft:"10%", width:"100px" }}>
               <Button size="large" style={{color:'white', paddingLeft:"20%"}}  href={`/${orgId}/payment`}>Donate</Button>
             </div>
-            <div style={{ float: "left", width: "3%", marginLeft:"10%"}}>
+            <div style={{ float: "right", width: "3%", marginLeft:"10%"}}>
               <IconButton onClick={() => router.push(`/${orgId}/login-sponsor`)}>
                 <PersonIcon style={{color:"#6c6c6c"}} />
               </IconButton>

--- a/components/templates/DetailedInfoModal.tsx
+++ b/components/templates/DetailedInfoModal.tsx
@@ -170,8 +170,8 @@ export function OrgModal(children: any) {
                             ) : (
                                 <Button style={{marginLeft:"30%", marginTop:"30px", color:"green"}} onClick={() => updateOrganizationStatus("Draft", org.id)} variant="outlined" href="#">Approve</Button>
                             )}
-                            <Button style={{marginLeft:"2%", marginTop:"30px", color:"red"}} onClick={() => updateOrganizationStatus("Under Review", org.id)} variant="outlined" href="#">Set under review</Button>
-                            <Button style={{marginLeft:"2%", marginTop:"30px", color:"red"}} onClick={() => updateOrganizationStatus("Disabled", org.id)} variant="outlined" href="#">Delete org</Button>
+                            <Button style={{marginLeft:"2%", marginTop:"30px", color:"red"}} onClick={() => updateOrganizationStatus("Under Review", org.id)} variant="outlined" href="#">Set as Under Review</Button>
+                            <Button style={{marginLeft:"2%", marginTop:"30px", color:"red"}} onClick={() => updateOrganizationStatus("Disabled", org.id)} variant="outlined" href="#">Disable</Button>
                         </div>
                     </div>
                 </div>

--- a/pages/[organizationId]/admin.tsx
+++ b/pages/[organizationId]/admin.tsx
@@ -69,7 +69,7 @@ import { Organization } from "."
                 </div>
                 <Container className={classes.heroContent}>
                     <Typography component="h2" variant="h3" align="center" color="textPrimary" gutterBottom >
-                    {organization.name} Admin panel
+                    "{organization.name}" Admin panel
                     </Typography>
                     <div style={{border:"1px solid", paddingTop:"10px", paddingBottom:"10px",  marginTop:"50px", width:"50%", marginLeft:"25%"}}>
                       <Typography align="center" color="primary"> The status of your organization is: <span style={{fontWeight:"bolder"}}>{organization.status}</span></Typography>

--- a/pages/[organizationId]/help.tsx
+++ b/pages/[organizationId]/help.tsx
@@ -1,9 +1,8 @@
-
-
 import {
     Container,
     Typography,
     NoSsr,
+    Link,
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
@@ -31,35 +30,32 @@ import { Organization } from "."
     },
   }));
   
-  function About({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  function Help({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
     const classes = useStyles(organization)
 
     return (
         <NoSsr>
           {organization ? (
             <BasePage className={classes.rootLight} title={organization.name} orgId={organization.id}>
-              <title>{organization.name} | About us</title>
+              <title>{organization.name} | How to help</title>
               <div className={classes.content}>
                 <Container>
-                  <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> About Us
+                  <Typography  variant="h3" align="center" color="primary" gutterBottom className={classes.infoText}> Thank you for your desire to help. Changing the world is easy with the team effort!
+                  </Typography>
+                  <Typography variant="h4" align="center" color="textSecondary" style={{marginTop:"200px", marginBottom:"50px"}}>
+                    Ways you can support us:
                   </Typography>
                   <Typography variant="h5" align="center" color="textSecondary" paragraph>
-                  {organization.tagline}
+                   -  <Link href={`/${organization.id}/payment`}>Donate to the organization or choose a specific child to support</Link> 
                   </Typography>
-                  <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Mission
+                  <Typography variant="h5" align="center" color="textSecondary" paragraph >
+                   - Subscribe to our newsletter on the homepage
                   </Typography>
-                  <Typography variant="h5" align="center" color="textSecondary" paragraph>
-                    {organization.mission}
+                  <Typography variant="h5" align="center" color="textSecondary" paragraph >
+                  - Share our details on your social media page
                   </Typography>
-                  <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Values
-                  </Typography>
-                  <Typography variant="h5" align="center" color="textSecondary" paragraph>
-                    {organization.vision}
-                  </Typography>
-                <Typography  variant="h3" align="center" color="textPrimary" gutterBottom className={classes.infoText}> Our Story
-                  </Typography>
-                  <Typography variant="h5" align="center" color="textSecondary" paragraph>
-                  {organization.story}
+                  <Typography variant="h5" align="center" color="textSecondary" paragraph >
+                  -  Volunteer your time, we have lots to enhance in our organization and need enthusiasts!
                   </Typography>
                 </Container>
               </div>
@@ -88,5 +84,5 @@ import { Organization } from "."
     }
   }
   
-  export default About
+  export default Help
   

--- a/pages/[organizationId]/profile.tsx
+++ b/pages/[organizationId]/profile.tsx
@@ -6,6 +6,7 @@ import {
     NoSsr,
     TextField,
     Button,
+    Link,
   } from "@material-ui/core"
   import { makeStyles } from "@material-ui/core/styles"
   import React from "react"
@@ -15,7 +16,7 @@ import { Organization } from "."
 import OrganizationService from "../../components/services/OrganizationService"
 import CountriesController from "../../components/autocomplete/Countries"
 import OrganizationLogo from "../../components/forms/OrganizationLogo"
-import { useRouter } from "next/router"
+import FavoriteIcon from '@material-ui/icons/Favorite'
 
   const useStyles = makeStyles((theme) => ({
     icon: {
@@ -43,7 +44,6 @@ import { useRouter } from "next/router"
   
   function Profile({ organization }: InferGetServerSidePropsType<typeof getServerSideProps>) {
     const classes = useStyles(organization)
-    const router = useRouter()
     const [orgData, setOrgData] = React.useState({
       address: organization.address,
       country:  {
@@ -141,8 +141,7 @@ import { useRouter } from "next/router"
           {status: "Published"},
           organization.id
       )
-
-      router.push(`/${organization.id}`)
+      setPage(page + 1)
   }
 
     const updateOrganization = () => {
@@ -172,15 +171,19 @@ import { useRouter } from "next/router"
                   <Typography variant="body1" align="center" color="textSecondary" paragraph>
                     On this page you can enter information related to your Organization, it will be displayed throughout the site.
                   </Typography>
-                  <div style={{border:"1px solid", paddingTop:"10px", paddingBottom:"10px", marginBottom:"30px", marginTop:"50px", width:"50%", marginLeft:"25%"}}>
-                    <Typography align="center" color="primary"> The status of your organization is: <span style={{fontWeight:"bolder"}}>{organization.status}</span></Typography>
-                    {page === 3 ? (
+                  {page != 4 ? (
+                    <div style={{border:"1px solid", paddingTop:"10px", paddingBottom:"10px", marginBottom:"30px", marginTop:"50px", width:"50%", marginLeft:"25%"}}>
+                      <Typography align="center" color="primary"> The status of your organization is: <span style={{fontWeight:"bolder"}}>{organization.status}</span></Typography>
+                      {page === 3 ? (
                       <Typography align="center" color="primary"> Preview your site and publish your organization, if it's still Pending.</Typography>
                       ):(
-                      <Typography align="center" color="primary"> Go to the final step to save changes or publish your organization.</Typography>
+                        <Typography align="center" color="primary"> Go to the final step to save changes or publish your organization.</Typography>
                       )
-                    }
-                  </div>
+                      }
+                    </div>
+                    ):(
+                      <></>
+                    )}
                   <div>
                     {page === 1 ? (
                       <div>
@@ -204,6 +207,13 @@ import { useRouter } from "next/router"
                       ) : ( <></> )}
                       {page === 3 ? (
                         <Typography style={{marginTop:"70px", marginLeft:"40%", color:"green"}}> Your organization is updated!</Typography>
+                        ) : ( <></> )
+                      }  
+                      {page === 4 ? (
+                        <div>
+                          <Typography variant="h6" style={{marginTop:"70px", marginLeft:"32%", color:"green"}}> Your organization is published, congratulations <FavoriteIcon/> </Typography>
+                          <Typography style={{marginTop:"30px", marginLeft:"35%", color:"green"}}> Here is the link to access it: <Link href={`http://localhost:3000/${organization.id}`} style={{color:"black", textDecoration:"underline"}}>http://localhost:3000/{organization.id}</Link></Typography>
+                        </div>
                         ) : ( <></> )
                       }    
                   </div>

--- a/pages/admin/all-organizations.tsx
+++ b/pages/admin/all-organizations.tsx
@@ -77,11 +77,20 @@ import { Button } from "@material-ui/core"
           <title>Admin | Mongen Initiative</title>
             <div style={{marginTop:"30px"}}>
                 <Link style={{marginLeft:"7%"}} href="/admin"> &larr; Back to Admin Panel</Link>
-                <Container maxWidth="sm" className={classes.heroContent}>
+                <Container maxWidth="md" className={classes.heroContent}>
                     <Typography component="h2" variant="h3" align="center" color="textPrimary" gutterBottom >
                         All organizations
                     </Typography>
-                     <div style={{ height: 550, width:"1100px", paddingTop:"50px", marginLeft:"-200px"}}>
+                    <div style={{border:"1px solid", paddingTop:"30px", paddingBottom:"40px", paddingLeft:"30px", marginBottom:"30px", marginTop:"50px", width:"100%"}}>
+                      <Typography align="center" color="primary" style={{marginBottom:"20px"}}> The flow: </Typography>
+                      <Typography color="primary"> 1. User sends a request to create an organization, it is created as  <span style={{fontWeight:"bolder"}}>Draft.</span></Typography>
+                      <Typography color="primary"> 2. Mongen Admin approves an organization by clicking "Summary" &#8211;&#62;	 Approve.</Typography>
+                      <Typography color="primary"> 3. The organization becomes <span style={{fontWeight:"bolder"}}>Pending</span>. Org main contact gets a link to the org admin page.</Typography>
+                      <Typography color="primary"> 4. Organization Admin can edit and publish the organization. It becomes <span style={{fontWeight:"bolder"}}>Published</span>. The website page is now available to anyone in the web.</Typography>
+                      <Typography color="primary"> 5. Mongen Admin can also mark a suspicious org as <span style={{fontWeight:"bolder"}}>Under Review</span>. The website page is still available to anyone in the web.</Typography>
+                      <Typography color="primary"> 6. Mongen Admin can also mark an org as <span style={{fontWeight:"bolder"}}>Disabled</span>. The website page is then becomes unavailable.</Typography>
+                    </div>
+                     <div style={{ height: 550, width:"1100px", paddingTop:"50px", marginLeft:"-10%"}}>
                       <DataGrid rows={organizations} columns={columns} pageSize={7} checkboxSelection />
                     </div>
                 </Container>

--- a/pages/admin/all-organizations.tsx
+++ b/pages/admin/all-organizations.tsx
@@ -51,15 +51,6 @@ import { Button } from "@material-ui/core"
         sortable: false,
         width: 150,
      },
-     {
-      field: 'button1',
-      headerName: '*',
-      renderCell: (params: ValueGetterParams) =>  (
-        <Button variant="outlined" href={`/${params.getValue('id')}/profile`}>Edit</Button>
-       ),
-      sortable: false,
-      width: 100,
-    },
     {
       field: 'button3',
       headerName: '*',

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -34,22 +34,23 @@ import { BasePageAboutMongen } from "../../components/templates";
                     <Typography component="h2" variant="h3" align="center" color="textPrimary" gutterBottom >
                     Admin panel
                     </Typography>
-                    <div style={{fontSize: "1.5em", paddingTop:"50px", paddingLeft:"15%"}}>
+                    {/* TODO: do we need it in a separate page, if on the all orgs page the table can be easily sorted */}
+                    {/* <div style={{fontSize: "1.5em", paddingTop:"50px", paddingLeft:"15%"}}>
                         -{" "} {" "} {" "}
                         <Link href="/admin/pending-organizations">
                             View the list of organizations pending review
                         </Link>
-                    </div>
-                    <div style={{fontSize: "1.5em", paddingTop:"10px", paddingLeft:"15%"}}>
+                    </div> */}
+                    <div style={{fontSize: "1.5em", paddingTop:"80px", paddingLeft:"20%"}}>
                         -{" "} {" "} {" "}
                         <Link href="/admin/all-organizations">
                             View the list of all organizations
                         </Link>
                     </div>
-                    <div style={{fontSize: "1.5em", paddingTop:"10px", paddingLeft:"15%"}}>
+                    <div style={{fontSize: "1.5em", paddingTop:"10px", paddingLeft:"20%"}}>
                         -{" "} {" "} {" "}
                         <Link href="/admin/create-organization">
-                            Create organization
+                            Create a new organization
                         </Link>
                     </div>
                 </Container>


### PR DESCRIPTION
- adding an info message about org review flow for Mongen Admin
<img width="1121" alt="Screenshot 2021-04-04 at 18 25 59" src="https://user-images.githubusercontent.com/44492659/113516669-76181700-9573-11eb-8ebd-67f121a33796.png">


- a template for "Help" page
- when publishing an org, I thought that showing a success message instead of directly going to the org page is a better UX.
<img width="1048" alt="Screenshot 2021-04-08 at 16 39 18" src="https://user-images.githubusercontent.com/44492659/114150979-8c77f700-9914-11eb-9011-b23c5ad96815.png">
